### PR TITLE
Add support for PDF base URL override in converter service

### DIFF
--- a/GeeksCoreLibrary.Modules.GclConverters.EvoPdf/Services/EvoPdfHtmlToPdfConverterService.cs
+++ b/GeeksCoreLibrary.Modules.GclConverters.EvoPdf/Services/EvoPdfHtmlToPdfConverterService.cs
@@ -224,6 +224,8 @@ public class EvoPdfHtmlToPdfConverterService : HtmlToPdfConverterService
          }
 
          var baseUri = httpContext == null ? null : HttpContextHelpers.GetBaseUri(httpContext).ToString();
+         baseUri = await objectsService.FindSystemObjectByDomainNameAsync("pdf_baseurl_override", baseUri);
+         
          var output = converter.ConvertHtml(htmlToConvert.ToString(), baseUri);
          var fileResult = new FileContentResult(output, "application/pdf")
          {


### PR DESCRIPTION
# Describe your changes

Allows the use of the system object `pdf_baseurl_override` to override the baseUrl that gets passed to evoPdf.
This gets used by evopdf to turn relative urls in the HTML to the correct absolute urls.

If no override is given it will still use the value derived from the httpContext.

## Type of change

Please check only ONE option.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Generated a pdf with the code change, having the baseUri be set to a different url.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests

N/A

# Link to Asana ticket

https://app.asana.com/1/5038780173035/project/1204297502076149/task/1209149354731038
