### PR TITLE
Upgrade EvoPdf.Chromium packages to EvoPdf.Next

### DIFF
--- a/GeeksCoreLibrary.Modules.GclConverters.EvoPdf/GeeksCoreLibrary.Modules.GclConverters.EvoPdf.csproj
+++ b/GeeksCoreLibrary.Modules.GclConverters.EvoPdf/GeeksCoreLibrary.Modules.GclConverters.EvoPdf.csproj
@@ -21,19 +21,18 @@
         <IsPackable>true</IsPackable>
     </PropertyGroup>
 
-    <!-- Packages with private assets. These packages will not be automatically/implicitly referenced in projects that use the GCL. -->
-    <!-- Developers have to add these packages via NuGet in their own projects. -->
-    <ItemGroup>
-        <!-- During NuGet restore the highest version will be used acros both packages, this would be 11.4.5 that is not available for Linux causing runtime issues. -->
-        <!-- By using a range for the Windows version, version 11.4.1 will be used when building for Linux. -->
-        <PackageReference Include="EvoPdf.Chromium.Windows" Version="[11.4.1,11.4.5]" PrivateAssets="all" />
-        <PackageReference Include="EvoPdf.Chromium.Linux" Version="11.4.1" PrivateAssets="all" />
-    </ItemGroup>
-
-    <!-- Normal package references. -->
     <ItemGroup>
         <PackageReference Include="GeeksCoreLibrary" Version="5.3.2605.2" />
     </ItemGroup>
+
+    <!-- Packages with private assets. These packages will not be automatically/implicitly referenced in projects that use the GCL. -->
+    <!-- Developers have to add these packages via NuGet in their own projects. -->
+    <ItemGroup>
+        <PackageReference Include="EvoPdf.Next.Windows" Version="14.6.2" PrivateAssets="all" />
+        <PackageReference Include="EvoPdf.Next.Linux" Version="14.6.2" PrivateAssets="all" />
+    </ItemGroup>
+
+    <!-- Normal package references. -->
 
     <!-- Copy the LICENSE and README.md files to the package -->
     <ItemGroup>

--- a/GeeksCoreLibrary.Modules.GclConverters.EvoPdf/Services/EvoPdfHtmlToPdfConverterService.cs
+++ b/GeeksCoreLibrary.Modules.GclConverters.EvoPdf/Services/EvoPdfHtmlToPdfConverterService.cs
@@ -1,6 +1,6 @@
 ﻿using System.Runtime.InteropServices;
 using System.Text;
-using EvoPdf.Chromium;
+using EvoPdf.Next;
 using GeeksCoreLibrary.Core.Helpers;
 using GeeksCoreLibrary.Core.Models;
 using GeeksCoreLibrary.Modules.Databases.Interfaces;
@@ -13,12 +13,12 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
+using EvoPdfLicensing = EvoPdf.Next.Licensing;
 
 namespace GeeksCoreLibrary.Modules.GclConverters.EvoPdf.Services;
 
 public class EvoPdfHtmlToPdfConverterService : HtmlToPdfConverterService
 {
-    private readonly GclSettings gclSettings;
     private readonly IObjectsService objectsService;
     private readonly IStringReplacementsService stringReplacementsService;
     private readonly IHttpContextAccessor? httpContextAccessor;
@@ -34,12 +34,13 @@ public class EvoPdfHtmlToPdfConverterService : HtmlToPdfConverterService
         this.objectsService = objectsService;
         this.stringReplacementsService = stringReplacementsService;
         this.httpContextAccessor = httpContextAccessor;
-        this.gclSettings = gclSettings.Value;
+
+        EvoPdfLicensing.LicenseKey = gclSettings.Value.EvoPdfLicenseKey;
 
         // Check if EvoPdf is loaded, otherwise throw an exception.
         // We load Evo PDF with PrivateAssets = true, so it won't be automatically loaded in projects that use the GCL.
         // This is because Evo PDF has separate packages for Windows and Linux, and we can't properly detect which one they need from here.
-        var evoPdfType = Type.GetType("EvoPdf.Chromium.HtmlToPdfConverter, EvoPdf.Chromium");
+        var evoPdfType = Type.GetType("EvoPdf.Next.HtmlToPdfConverter, EvoPdf.Next");
         if (evoPdfType == null)
         {
             throw new InvalidOperationException("EvoPdf is not loaded. Please ensure you have added the correct NuGet package: Either 'EvoPdf.Chromium.Windows' for Windows or 'EvoPdf.Chromium.Linux' for Linux.");
@@ -53,7 +54,6 @@ public class EvoPdfHtmlToPdfConverterService : HtmlToPdfConverterService
          var httpContext = httpContextAccessor?.HttpContext;
          var converter = new HtmlToPdfConverter
          {
-             LicenseKey = gclSettings.EvoPdfLicenseKey,
              ConversionDelay = 2
          };
 

--- a/README.md
+++ b/README.md
@@ -10,21 +10,21 @@ If you do want to use Evo PDF, you need to add a reference to `EvoPdf.Chromium.W
 ```xml
 <!-- Default PackageReference when no RuntimeIdentifier is specified -->
 <ItemGroup Condition="'$(RuntimeIdentifier)' == '' AND $([MSBuild]::IsOsPlatform('Windows'))">
-    <PackageReference Include="EvoPdf.Chromium.Windows" Version="11.4.5" />
+    <PackageReference Include="EvoPdf.Next.Windows" Version="14.6.2" />
 </ItemGroup>
 
 <ItemGroup Condition="'$(RuntimeIdentifier)' == '' AND $([MSBuild]::IsOsPlatform('Linux'))">
-    <PackageReference Include="EvoPdf.Chromium.Linux" Version="11.4.1" />
+    <PackageReference Include="EvoPdf.Next.Linux" Version="14.6.2" />
 </ItemGroup>
 
 <!-- Windows-specific dependency -->
 <ItemGroup Condition="'$(RuntimeIdentifier)' == 'win-x64'">
-    <PackageReference Include="EvoPdf.Chromium.Windows" Version="11.4.5" />
+    <PackageReference Include="EvoPdf.Next.Windows" Version="14.6.2" />
 </ItemGroup>
 
 <!-- Linux-specific dependency -->
 <ItemGroup Condition="'$(RuntimeIdentifier)' == 'linux-x64'">
-    <PackageReference Include="EvoPdf.Chromium.Linux" Version="11.4.1" />
+    <PackageReference Include="EvoPdf.Next.Linux" Version="14.6.2" />
 </ItemGroup>
 ```
 


### PR DESCRIPTION
# Describe your changes

Upgrade EvoPdf.Chromium packages to EvoPdf.Next. This is needed because the EvoPdf.Chromium are no longer available via Nuget.

Do keep in mind that the evopdf package references need to be be updated as well and this version might require a different licence key because this uses a different major version of EvoPdf

## Type of change

Please check only ONE option.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Tested it in the pdf generation part of the order process of a customer.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests

N/A

# Link to Asana ticket

N/A
